### PR TITLE
Reallocate IPs to accommodate extra external nets

### DIFF
--- a/etc/kayobe/environments/production/network-allocation.yml
+++ b/etc/kayobe/environments/production/network-allocation.yml
@@ -6,33 +6,33 @@ external_ceph_net_ips:
   controller2: 172.16.0.2
   controller3: 172.16.0.3
   controller4: 172.16.0.4
-external_internet_ips:
-  controller1: 10.129.31.10
-  controller2: 10.129.31.11
-  controller3: 10.129.31.12
-  controller4: 10.129.31.13
 external_internet_net_ips:
-  controller1: null
-  controller2: null
-  controller3: null
-  controller4: null
+  controller1: 10.129.30.10
+  controller2: 10.129.30.11
+  controller3: 10.129.30.12
+  controller4: 10.129.30.13
+external_api_net_ips:
+  controller1: 10.129.26.130
+  controller2: 10.129.26.131
+  controller3: 10.129.26.132
+  controller4: 10.129.26.133
 external_intranet_net_ips:
   dl-ansible-01: null
 internal_net_ips:
-  compute1: 10.129.30.21
-  compute2: 10.129.30.22
-  compute3: 10.129.30.23
-  compute4: 10.129.30.24
-  compute5: 10.129.30.25
-  compute6: 10.129.30.26
-  compute7: 10.129.30.27
-  compute8: 10.129.30.28
-  controller1: 10.129.30.12
-  controller2: 10.129.30.13
-  controller3: 10.129.30.14
-  controller4: 10.129.30.15
-  gpu1: 10.129.30.31
-  gpu2: 10.129.30.32
+  compute1: 10.129.26.21
+  compute2: 10.129.26.22
+  compute3: 10.129.26.23
+  compute4: 10.129.26.24
+  compute5: 10.129.26.25
+  compute6: 10.129.26.26
+  compute7: 10.129.26.27
+  compute8: 10.129.26.28
+  controller1: 10.129.26.12
+  controller2: 10.129.26.13
+  controller3: 10.129.26.14
+  controller4: 10.129.26.15
+  gpu1: 10.129.26.31
+  gpu2: 10.129.26.32
 power_mgmt_net_ips:
   ansible-bmc: 10.129.24.10
   compute1: 10.129.24.21
@@ -72,10 +72,10 @@ provision_ctl_net_ips:
   gpu1: 10.129.28.31
   gpu2: 10.129.28.32
 storage_mgmt_net_ips:
-  controller1: 10.129.26.11
-  controller2: 10.129.26.12
-  controller3: 10.129.26.13
-  controller4: 10.129.26.14
+  controller1: 10.129.26.74
+  controller2: 10.129.26.76
+  controller3: 10.129.26.77
+  controller4: 10.129.26.78
 storage_net_ips:
   compute1: 10.129.27.21
   compute2: 10.129.27.22
@@ -92,17 +92,17 @@ storage_net_ips:
   gpu1: 10.129.27.31
   gpu2: 10.129.27.32
 tenant_tunnel_net_ips:
-  compute1: 10.129.29.21
-  compute2: 10.129.29.22
-  compute3: 10.129.29.23
-  compute4: 10.129.29.24
-  compute5: 10.129.29.25
-  compute6: 10.129.29.26
-  compute7: 10.129.29.27
-  compute8: 10.129.29.28
-  controller1: 10.129.29.12
-  controller2: 10.129.29.13
-  controller3: 10.129.29.14
-  controller4: 10.129.29.15
-  gpu1: 10.129.29.31
-  gpu2: 10.129.29.32
+  compute1: 10.129.27.141
+  compute2: 10.129.27.142
+  compute3: 10.129.27.143
+  compute4: 10.129.27.144
+  compute5: 10.129.27.145
+  compute6: 10.129.27.146
+  compute7: 10.129.27.147
+  compute8: 10.129.27.148
+  controller1: 10.129.27.131
+  controller2: 10.129.27.132
+  controller3: 10.129.27.133
+  controller4: 10.129.27.134
+  gpu1: 10.129.27.151
+  gpu2: 10.129.27.152

--- a/etc/kayobe/environments/production/network-allocation.yml
+++ b/etc/kayobe/environments/production/network-allocation.yml
@@ -6,7 +6,7 @@ external_ceph_net_ips:
   controller2: 172.16.0.2
   controller3: 172.16.0.3
   controller4: 172.16.0.4
-external_internet_net_ips:
+external_internet_ips:
   controller1: 10.129.30.10
   controller2: 10.129.30.11
   controller3: 10.129.30.12
@@ -16,7 +16,7 @@ external_api_net_ips:
   controller2: 10.129.26.131
   controller3: 10.129.26.132
   controller4: 10.129.26.133
-external_intranet_net_ips:
+external_intranet_ips:
   dl-ansible-01: null
 internal_net_ips:
   compute1: 10.129.26.21
@@ -72,7 +72,7 @@ provision_ctl_net_ips:
   gpu1: 10.129.28.31
   gpu2: 10.129.28.32
 storage_mgmt_net_ips:
-  controller1: 10.129.26.74
+  controller1: 10.129.26.75
   controller2: 10.129.26.76
   controller3: 10.129.26.77
   controller4: 10.129.26.78

--- a/etc/kayobe/environments/production/networks.yml
+++ b/etc/kayobe/environments/production/networks.yml
@@ -21,31 +21,31 @@ provision_ctl_net_switch_vlan: 3
 provision_ctl_net_mtu: 1500
 
 # Internal API network IP information.
-internal_net_vip_address: "10.129.30.2"
-internal_net_cidr: "10.129.30.0/24"
-internal_net_allocation_pool_start: "10.129.30.10"
-internal_net_allocation_pool_end: "10.129.30.250"
+internal_net_vip_address: "10.129.26.2"
+internal_net_cidr: "10.129.26.0/26"
+internal_net_allocation_pool_start: "10.129.26.10"
+internal_net_allocation_pool_end: "10.129.26.58"
 internal_net_vlan: 4
 internal_net_mtu: 9000
 
 # Storage network IP information.
-storage_net_cidr: "10.129.27.0/24"
+storage_net_cidr: "10.129.27.0/25"
 storage_net_allocation_pool_start: "10.129.27.10"
-storage_net_allocation_pool_end: "10.129.27.250"
+storage_net_allocation_pool_end: "10.129.27.120"
 storage_net_vlan: 5
 storage_net_mtu: 9000
 
 # Storage Management network IP information.
-storage_mgmt_net_cidr: "10.129.26.0/24"
-storage_mgmt_net_allocation_pool_start: "10.129.26.10"
-storage_mgmt_net_allocation_pool_end: "10.129.26.250"
+storage_mgmt_net_cidr: "10.129.26.64/26"
+storage_mgmt_net_allocation_pool_start: "10.129.26.74"
+storage_mgmt_net_allocation_pool_end: "10.129.26.124"
 storage_mgmt_net_vlan: 6
 storage_mgmt_net_mtu: 9000
 
 # Tenant/Tunnel network IP information.
-tenant_tunnel_net_cidr: "10.129.29.0/24"
-tenant_tunnel_net_allocation_pool_start: "10.129.29.10"
-tenant_tunnel_net_allocation_pool_end: "10.129.29.250"
+tenant_tunnel_net_cidr: "10.129.27.128/25"
+tenant_tunnel_net_allocation_pool_start: "10.129.27.130"
+tenant_tunnel_net_allocation_pool_end: "10.129.29.248"
 tenant_tunnel_net_vlan: 7
 tenant_tunnel_net_mtu: 9150
 
@@ -67,28 +67,33 @@ external_admin_net_gateway: "10.129.25.246"
 
 # External/Intranet network IP information.
 # There aren't any control plane hosts bound to this network
-#TODO(mattc): Request another /24 range, or set this to a 192. range. The .32 subnet here is not yet available to us.
-external_intranet_cidr: #"10.129.32.0/24"
+external_intranet_cidr: "10.129.29.0/24"
 external_intranet_vlan: 2804
 external_intranet_mtu: 1500
-external_intranet_gateway: #"10.129.32.1"
+#external_intranet_gateway: "10.129.29.246"
 
 # External/Internet network IP information.
-# OpenStack PublicAPI hosts sit at bottom of this subnet
-# FIXME: placeholder content
-external_internet_fqdn: "placeholder.bristol.ac.uk"
-external_internet_cidr: "10.129.31.0/24"
-external_internet_allocation_pool_start: "10.129.31.10"
+# Default gateway for tenant traffic sits at bottom of this subnet
+external_internet_cidr: "10.129.30.0/23"
+external_internet_allocation_pool_start: "10.129.30.10"
 external_internet_allocation_pool_end: "10.129.31.240"
 external_internet_vlan: 2803
 external_internet_mtu: 1500
 external_internet_gateway: "10.129.31.254"
+
+# External/API network IP information.
+# OpenStack PublicAPI hosts sit at bottom of this subnet
 # VIP address for public API endpoints.
-external_internet_vip_address: "10.129.31.1"
+external_api_vip_address: "10.129.26.129"
+external_api_cidr: "10.129.26.128/26"
+external_api_allocation_pool_start: "10.129.26.130"
+external_api_allocation_pool_end: "10.129.26.188"
+external_api_vlan: 2805
+external_api_mtu: 1500
+#external_api_gateway: "10.129.26.190"
 # FQDN address for public API endpoints, registered with the external DNS
 # server to resolve to the public VIP address.
-
-# Workload proviver network?
+external_api_fqdn: "placeholder.acrc.bris.ac.uk"
 
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.

--- a/etc/kayobe/environments/production/networks.yml
+++ b/etc/kayobe/environments/production/networks.yml
@@ -84,16 +84,16 @@ external_internet_gateway: "10.129.31.254"
 # External/API network IP information.
 # OpenStack PublicAPI hosts sit at bottom of this subnet
 # VIP address for public API endpoints.
-external_api_vip_address: "10.129.26.129"
-external_api_cidr: "10.129.26.128/26"
-external_api_allocation_pool_start: "10.129.26.130"
-external_api_allocation_pool_end: "10.129.26.188"
-external_api_vlan: 2805
-external_api_mtu: 1500
-#external_api_gateway: "10.129.26.190"
+external_api_net_vip_address: "10.129.26.129"
+external_api_net_cidr: "10.129.26.128/26"
+external_api_net_allocation_pool_start: "10.129.26.130"
+external_api_net_allocation_pool_end: "10.129.26.188"
+external_api_net_vlan: 2805
+external_api_net_mtu: 1500
+#external_api_net_gateway: "10.129.26.190"
 # FQDN address for public API endpoints, registered with the external DNS
 # server to resolve to the public VIP address.
-external_api_fqdn: "placeholder.acrc.bris.ac.uk"
+external_api_net_fqdn: "placeholder.acrc.bris.ac.uk"
 
 ###############################################################################
 # Dummy variable to allow Ansible to accept this file.

--- a/etc/kayobe/inventory/group_vars/hs-switches
+++ b/etc/kayobe/inventory/group_vars/hs-switches
@@ -73,6 +73,11 @@ switch_interface_config_vlans_template: |-
     config:
       - no shutdown
       - mtu {{ external_intranet_mtu }}
+  vlan {{ external_api_net_vlan }}:
+    description: Public-API
+    config:
+      - no shutdown
+      - mtu {{ external_api_net_mtu }}
 
 switch_interface_config_vlans: "{{ switch_interface_config_vlans_template | from_yaml }}"
 
@@ -162,6 +167,7 @@ switch_controller_trunk_ctl_vlans:
 #  - "{{ provision_ctl_net_switch_vlan }}"
   - "{{ external_internet_vlan }}"
   - "{{ external_intranet_vlan }}"
+  - "{{ external_api_net_vlan }}"
 
 # VLANs to trunk to compute nodes on the high-speed interface
 switch_compute_trunk_hs_vlans:
@@ -175,6 +181,7 @@ switch_compute_trunk_ctl_vlans:
 #  - "{{ provision_ctl_net_switch_vlan }}"
   - "{{ external_internet_vlan }}"
   - "{{ external_intranet_vlan }}"
+  - "{{ external_api_net_vlan }}"
 
 ###############################################################################
 # Switch global config

--- a/etc/kayobe/networks.yml
+++ b/etc/kayobe/networks.yml
@@ -33,9 +33,10 @@ internal_net_name: "internal_net"
 # containing one item, external_net_name.
 external_net_names:
   - "external_internet"
+  - "external_intranet"
 
 # Name of the network used to expose the public OpenStack API endpoints.
-public_net_name: "external_internet"
+public_net_name: "external_api"
 
 # Name of the network used by Neutron to carry tenant overlay network traffic.
 tunnel_net_name: "tenant_tunnel_net"

--- a/etc/kayobe/networks.yml
+++ b/etc/kayobe/networks.yml
@@ -36,7 +36,7 @@ external_net_names:
   - "external_intranet"
 
 # Name of the network used to expose the public OpenStack API endpoints.
-public_net_name: "external_api"
+public_net_name: "external_api_net"
 
 # Name of the network used by Neutron to carry tenant overlay network traffic.
 tunnel_net_name: "tenant_tunnel_net"


### PR DESCRIPTION
Squeezes networks comprised only of control plane hosts onto smaller subnets to accommodate extra `public_api` & `external_intranet` nets and expanding of `external_internet` net.
