### PR TITLE
Resolve final issues with vflag implementation

### DIFF
--- a/etc/kayobe/inventory/group_vars/hs-switches
+++ b/etc/kayobe/inventory/group_vars/hs-switches
@@ -95,7 +95,7 @@ switch_interface_config_lag_member_template: |-
   - flowcontrol transmit on
   - lldp tlv-select basic-tlv management-address port-description system-name
   - lldp tlv-select dcbxp
-  - channel-group %(channel)d mode active
+  - channel-group %(channel)d mode passive
 
 # OpenStack compute hypervisor data interface configuration
 switch_interface_config_lag_member: "{{ switch_interface_config_lag_member_template | from_yaml }}"

--- a/etc/kayobe/kolla/globals.yml
+++ b/etc/kayobe/kolla/globals.yml
@@ -75,7 +75,7 @@ prometheus_cmdline_extras: "--storage.tsdb.retention.time=30d"
 # Additional command line flags for node exporter to enable texfile collector for disk metrics and create textfile docker volume
 prometheus_node_exporter_extra_volumes:
   - "textfile:/var/lib/node_exporter/textfile_collector"
-prometheus_node_exporter_cmdline_extras: "--collector.textfile.directory=/var/lib/node_exporter/textfile_collector"
+prometheus_node_exporter_cmdline_extras: "--collector.textfile.directory=/var/lib/node_exporter/textfile_collector --no-collector.netclass"
 
 # Set Ceph manager exporter endpoints
 {% if groups['mgrs'] | length > 0 %}


### PR DESCRIPTION
Switching the lag port channels' mode to passive reduced the number of failing hosts. The netclass prometheus node exporter collector was found to be the cause of the crashes. This is disabled.