### PR TITLE
CIS hardening

### DIFF
--- a/etc/kayobe/ansible/cis.yml
+++ b/etc/kayobe/ansible/cis.yml
@@ -4,12 +4,23 @@
   hosts: overcloud
   become: true
   tasks:
+    - name: Ensure the cron package is installed on ubuntu
+      package:
+        name: cron
+        state: present
+      when: ansible_facts.distribution == 'Ubuntu'
     - name: Remove /etc/motd
       # See remediation in:
       # https://github.com/wazuh/wazuh/blob/bfa4efcf11e288c0a8809dc0b45fdce42fab8e0d/ruleset/sca/centos/8/cis_centos8_linux.yml#L777
       file:
         path: /etc/motd
         state: absent
+      when: ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '8'
 
     - include_role:
         name: ansible-lockdown.rhel8_cis
+      when: ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '8'
+    
+    - include_role:
+        name: ansible-lockdown.ubuntu22_cis
+      when: ansible_facts.distribution == 'Ubuntu' and ansible_facts.distribution_major_version == '22'

--- a/etc/kayobe/ansible/cis.yml
+++ b/etc/kayobe/ansible/cis.yml
@@ -9,6 +9,7 @@
         name: cron
         state: present
       when: ansible_facts.distribution == 'Ubuntu'
+
     - name: Remove /etc/motd
       # See remediation in:
       # https://github.com/wazuh/wazuh/blob/bfa4efcf11e288c0a8809dc0b45fdce42fab8e0d/ruleset/sca/centos/8/cis_centos8_linux.yml#L777

--- a/etc/kayobe/ansible/requirements.yml
+++ b/etc/kayobe/ansible/requirements.yml
@@ -20,3 +20,6 @@ roles:
   - name: wazuh-ansible
     src: https://github.com/stackhpc/wazuh-ansible
     version: stackhpc
+  - name: ansible-lockdown.ubuntu22_cis
+    src: https://github.com/ansible-lockdown/UBUNTU22-CIS
+    version: 2bbaefb3de539fc475f8924fc494857a2845c3fd

--- a/etc/kayobe/inventory/group_vars/overcloud/cis
+++ b/etc/kayobe/inventory/group_vars/overcloud/cis
@@ -1,5 +1,6 @@
 ---
 
+# RedHat 8 CIS configuration
 # NOTE: kayobe configures NTP. Do not clobber configuration.
 rhel8cis_time_synchronization: skip
 rhel8cis_rule_2_2_1_1: false
@@ -22,3 +23,52 @@ rhel8cis_crypto_policy: FIPS
 # from being displayed.
 rhel8cis_rule_1_8_1_1: false
 rhel8cis_rule_1_8_1_4: false
+
+# Ubuntu 22 CIS configuration
+# Disable changing routing rules
+ubtu22cis_is_router: true
+
+# Set Chrony as the time sync tool
+ubtu22cis_time_sync_tool: "chrony"
+
+# Disable CIS from configuring the firewall
+ubtu22cis_firewall_package: "none"
+
+# Stop CIS from installing Network Manager
+ubtu22cis_install_network_manager: false
+
+# Set syslog service to journald
+ubtu22cis_syslog_service: journald
+
+# Squashfs is compiled into the kernel
+ubtu22cis_rule_1_1_1_2: false
+
+# This updates the system. Let's do this explicitly.
+ubtu22cis_rule_1_9: false
+
+# Do not change Chrony Time servers
+ubtu22cis_rule_2_1_2_1: false
+
+# Disable CIS from touching sudoers
+ubtu22cis_rule_5_3_4: false
+
+# Add stack and kolla to allowed ssh users
+ubtu22cis_sshd:
+    log_level: "INFO"
+    max_auth_tries: 4
+    ciphers: "chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr"
+    macs: "hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256"
+    kex_algorithms: "curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256"
+    client_alive_interval: 300
+    client_alive_count_max: 3
+    login_grace_time: 60
+    max_sessions: 10
+    allow_users: "kolla stack ubuntu"
+    allow_groups: "kolla stack ubuntu"
+
+# Do not change /var/lib/docker permissions
+ubtu22cis_no_group_adjust: false
+ubtu22cis_no_owner_adjust: false
+
+# Enable collecting auditd logs
+update_audit_template: true


### PR DESCRIPTION
Updates the cis.yml playbook and adds group vars for the hardening. Additionally adds the ansible lockdown ubuntu22 role to ansible requirements.